### PR TITLE
VTN-9100 Add retry policy to Golang GraphQL client

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -288,7 +288,7 @@ func (c *Client) runWithPostFields(ctx context.Context, req *Request, resp inter
 	}
 	c.logf(">> headers: %v", r.Header)
 	r = r.WithContext(ctx)
-	res, err := c.httpClient.Do(r)
+	res, err := c.sendRequest(r)
 	if err != nil {
 		return err
 	}

--- a/graphql_retry_test.go
+++ b/graphql_retry_test.go
@@ -16,7 +16,7 @@ import (
 func TestLinearPolicy(t *testing.T) {
 	is := is.New(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotImplemented)
+		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
 	defer srv.Close()
 
@@ -41,7 +41,7 @@ func TestLinearPolicy(t *testing.T) {
 func TestNoPolicySpecified(t *testing.T) {
 	is := is.New(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotImplemented)
+		w.WriteHeader(http.StatusServiceUnavailable)
 
 		is.Equal(r.Method, http.MethodPost)
 		b, err := ioutil.ReadAll(r.Body)
@@ -99,7 +99,7 @@ func TestCustomRetryStatus(t *testing.T) {
 func TestExponentialBackoffPolicy(t *testing.T) {
 	is := is.New(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotImplemented)
+		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
 	defer srv.Close()
 

--- a/graphql_retry_test.go
+++ b/graphql_retry_test.go
@@ -1,0 +1,123 @@
+package graphql
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/matryer/is"
+)
+
+func TestLinearPolicy(t *testing.T) {
+	is := is.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	retryConfig := RetryConfig{
+		Policy:      Linear,
+		MaxTries:    3,
+		Interval:    1,
+		MaxInterval: 10,
+	}
+	client := NewClient(srv.URL, WithRetryConfig(retryConfig))
+
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	var responseData map[string]interface{}
+	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)
+	if !strings.HasPrefix(err.Error(), "Error getting response with retry:") {
+		is.Fail()
+	}
+}
+
+func TestNoPolicySpecified(t *testing.T) {
+	is := is.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+
+		is.Equal(r.Method, http.MethodPost)
+		b, err := ioutil.ReadAll(r.Body)
+		is.NoErr(err)
+		is.Equal(string(b), `{"query":"query {}","variables":null}`+"\n")
+		io.WriteString(w, `{
+			"data": {
+				"something": "yes"
+			}
+		}`)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	retryConfig := RetryConfig{}
+	client := NewClient(srv.URL, WithRetryConfig(retryConfig))
+
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	var responseData map[string]interface{}
+	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)
+	is.NoErr(err)
+	is.Equal(responseData["something"], "yes")
+}
+
+func TestCustomRetryStatus(t *testing.T) {
+	is := is.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	retryStatus := make(map[int]bool)
+	retryStatus[http.StatusOK] = true
+	retryConfig := RetryConfig{
+		Policy:      Linear,
+		MaxTries:    3,
+		Interval:    1,
+		MaxInterval: 10,
+		RetryStatus: retryStatus,
+	}
+	client := NewClient(srv.URL, WithRetryConfig(retryConfig))
+
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	var responseData map[string]interface{}
+	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)
+	t.Logf("error: %s", err)
+	if !strings.HasPrefix(err.Error(), "Error getting response with retry:") {
+		is.Fail()
+	}
+}
+
+func TestExponentialBackoffPolicy(t *testing.T) {
+	is := is.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	retryConfig := RetryConfig{
+		Policy:      ExponentialBackoff,
+		MaxTries:    3,
+		Interval:    1,
+		MaxInterval: 10,
+	}
+	client := NewClient(srv.URL, WithRetryConfig(retryConfig))
+
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	var responseData map[string]interface{}
+	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)
+	t.Logf("error: %s", err)
+	if !strings.HasPrefix(err.Error(), "Error getting response with retry:") {
+		is.Fail()
+	}
+}


### PR DESCRIPTION
## Overview
* Add retry policy capability for the client
* Add unit test to ensure retrying works

## Test
* Unit test passed
* Local test
  * Start coordinator first with retry config implemented:
```go
retryConfig := graphql.RetryConfig{
	MaxTries:    100,
	Interval:    3,
	Policy:      graphql.Linear,
	MaxInterval: 100,
}
cl := graphql.NewClient(endpoint, withAuthHeader(token, timeoutDur), graphql.WithRetryConfig(retryConfig))
```
  * Let it run for awhile, we'd get logs look like:
```bash
2018/07/20 14:16:26 Will retry after interval expires
2018/07/20 14:16:26 Waiting for interval(3.000000) to expire...
2018/07/20 14:16:29 New interval: 3.000000
2018/07/20 14:16:29 Will retry after interval expires
2018/07/20 14:16:29 Waiting for interval(3.000000) to expire...
2018/07/20 14:16:32 New interval: 3.000000
2018/07/20 14:16:32 Will retry after interval expires
2018/07/20 14:16:32 Waiting for interval(3.000000) to expire...
2018/07/20 14:16:35 New interval: 3.000000
2018/07/20 14:16:35 Will retry after interval expires
2018/07/20 14:16:35 Waiting for interval(3.000000) to expire...
```
  * Start up core-graphql-server, we'd get the follow:
```bash
{"level":"info","message":"\u003c\u003c {\"data\":{\"me\":{\"id\":\"d6323f58-1053-4a06-af92-81220647f691\"}}}","timestamp":"2018-07-20T14:16:54-07:00"}
{"level":"info","message":"Initialized GraphQL client successfully using endpoint: http://localhost:3000/graphql","timestamp":"2018-07-20T14:16:54-07:00"}
```