### PR TITLE
VTN-9202 Parallelize unit test to improve runtime

### DIFF
--- a/graphql_retry_test.go
+++ b/graphql_retry_test.go
@@ -18,6 +18,7 @@ func getTestDuration(sec int) time.Duration {
 }
 
 func TestLinearPolicy(t *testing.T) {
+	t.Parallel()
 	is := is.New(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -40,6 +41,7 @@ func TestLinearPolicy(t *testing.T) {
 }
 
 func TestNoPolicySpecified(t *testing.T) {
+	t.Parallel()
 	is := is.New(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -71,6 +73,7 @@ func TestNoPolicySpecified(t *testing.T) {
 }
 
 func TestCustomRetryStatus(t *testing.T) {
+	t.Parallel()
 	is := is.New(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -101,6 +104,7 @@ func TestCustomRetryStatus(t *testing.T) {
 }
 
 func TestExponentialBackoffPolicy(t *testing.T) {
+	t.Parallel()
 	is := is.New(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -113,7 +117,7 @@ func TestExponentialBackoffPolicy(t *testing.T) {
 		t.Log(str)
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, getTestDuration(16))
+	ctx, cancel := context.WithTimeout(ctx, getTestDuration(31))
 	defer cancel()
 	var responseData map[string]interface{}
 	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)


### PR DESCRIPTION
## Overview
* Previously, retry unit tests ran slowly in sequence. Now, with the parallel setup, it runs in 30s instead of 40s.
* Also fix unit test to accommodate to recent change on default policy

## Test
```bash
VTN-00027-(Duy-Nguyen):graphql duynguyen$ go test -v
=== RUN   TestDoJSON
--- PASS: TestDoJSON (0.00s)
=== RUN   TestQueryJSON
--- PASS: TestQueryJSON (0.00s)
=== RUN   TestHeader
--- PASS: TestHeader (0.00s)
=== RUN   TestWithClient
--- PASS: TestWithClient (0.00s)
=== RUN   TestDoUseMultipartForm
--- PASS: TestDoUseMultipartForm (0.00s)
=== RUN   TestDoErr
--- PASS: TestDoErr (0.00s)
=== RUN   TestDoNoResponse
--- PASS: TestDoNoResponse (0.00s)
=== RUN   TestQuery
--- PASS: TestQuery (0.00s)
=== RUN   TestFile
--- PASS: TestFile (0.00s)
=== RUN   TestLinearPolicy
=== PAUSE TestLinearPolicy
=== RUN   TestNoPolicySpecified
=== PAUSE TestNoPolicySpecified
=== RUN   TestCustomRetryStatus
=== PAUSE TestCustomRetryStatus
=== RUN   TestExponentialBackoffPolicy
=== PAUSE TestExponentialBackoffPolicy
=== CONT  TestLinearPolicy
=== CONT  TestExponentialBackoffPolicy
=== CONT  TestCustomRetryStatus
=== CONT  TestNoPolicySpecified
--- PASS: TestNoPolicySpecified (0.00s)
	graphql_retry_test.go:64: >> variables: map[]
	graphql_retry_test.go:64: >> query: query {}
	graphql_retry_test.go:64: >> headers: map[Content-Type:[application/json; charset=utf-8] Accept:[application/json; charset=utf-8]]
	graphql_retry_test.go:64: << {
					"data": {
						"something": "yes"
					}
				}
--- PASS: TestCustomRetryStatus (1.00s)
	graphql_retry_test.go:94: >> variables: map[]
	graphql_retry_test.go:94: >> query: query {}
	graphql_retry_test.go:94: >> headers: map[Content-Type:[application/json; charset=utf-8] Accept:[application/json; charset=utf-8]]
	graphql_retry_test.go:94: Will retry after interval expires
	graphql_retry_test.go:94: Waiting for interval(1.000000) to expire...
	graphql_retry_test.go:94: New interval: 1.000000
--- PASS: TestLinearPolicy (10.01s)
	graphql_retry_test.go:31: >> variables: map[]
	graphql_retry_test.go:31: >> query: query {}
	graphql_retry_test.go:31: >> headers: map[Content-Type:[application/json; charset=utf-8] Accept:[application/json; charset=utf-8]]
	graphql_retry_test.go:31: Will retry after interval expires
	graphql_retry_test.go:31: Waiting for interval(2.000000) to expire...
	graphql_retry_test.go:31: New interval: 2.000000
	graphql_retry_test.go:31: Will retry after interval expires
	graphql_retry_test.go:31: Waiting for interval(2.000000) to expire...
	graphql_retry_test.go:31: New interval: 2.000000
	graphql_retry_test.go:31: Will retry after interval expires
	graphql_retry_test.go:31: Waiting for interval(2.000000) to expire...
	graphql_retry_test.go:31: New interval: 2.000000
	graphql_retry_test.go:31: Will retry after interval expires
	graphql_retry_test.go:31: Waiting for interval(2.000000) to expire...
	graphql_retry_test.go:31: New interval: 2.000000
	graphql_retry_test.go:31: Will retry after interval expires
	graphql_retry_test.go:31: Waiting for interval(2.000000) to expire...
	graphql_retry_test.go:31: New interval: 2.000000
--- PASS: TestExponentialBackoffPolicy (31.01s)
	graphql_retry_test.go:117: >> variables: map[]
	graphql_retry_test.go:117: >> query: query {}
	graphql_retry_test.go:117: >> headers: map[Content-Type:[application/json; charset=utf-8] Accept:[application/json; charset=utf-8]]
	graphql_retry_test.go:117: Will retry after interval expires
	graphql_retry_test.go:117: Waiting for interval(1.000000) to expire...
	graphql_retry_test.go:117: New interval: 2.000000
	graphql_retry_test.go:117: Will retry after interval expires
	graphql_retry_test.go:117: Waiting for interval(2.000000) to expire...
	graphql_retry_test.go:117: New interval: 4.000000
	graphql_retry_test.go:117: Will retry after interval expires
	graphql_retry_test.go:117: Waiting for interval(4.000000) to expire...
	graphql_retry_test.go:117: New interval: 8.000000
	graphql_retry_test.go:117: Will retry after interval expires
	graphql_retry_test.go:117: Waiting for interval(8.000000) to expire...
	graphql_retry_test.go:117: New interval: 16.000000
	graphql_retry_test.go:117: Will retry after interval expires
	graphql_retry_test.go:117: Waiting for interval(16.000000) to expire...
	graphql_retry_test.go:117: New interval: 16.000000
PASS
ok  	github.com/veritone/graphql	31.042s
```