### PR TITLE
VTN-32452, Add a option to retry when api service unstable

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -254,6 +254,13 @@ func WithDefaultHeaders(defaultHeaders map[string]string) ClientOption {
 	}
 }
 
+// WithEnableCloseHTTPRequest provides a option to close the request or not
+func WithEnableCloseHTTPRequest() ClientOption {
+	return func(client *clientImp) {
+		client.closeReq = true
+	}
+}
+
 // Run executes the query and unmarshals the response from the data field
 // into the response object.
 // Pass in a nil response object to skip response parsing.


### PR DESCRIPTION
Ticket: https://steel-ventures.atlassian.net/browse/VTN-32452
In PMI, We have a lot of fail tasks relate to API's issue.
Should add this option to reduce failure rate.
For example:
![image](https://user-images.githubusercontent.com/33303166/70740152-19c03100-1d4b-11ea-95a5-3f7beda996d6.png)

